### PR TITLE
configure: add support for when ccache is called before the compiler

### DIFF
--- a/configure
+++ b/configure
@@ -76,7 +76,15 @@ fnmatch () {
 }
 
 cmdexists () {
-  type "$1" >/dev/null 2>&1
+  local status=0;
+  for cmdpart in $1; do
+    type "$cmdpart" 2>&1 >/dev/null
+    status=$?
+    if [ $status -ne 0 ]; then
+      break
+    fi
+  done
+  return $status
 }
 
 trycc () {
@@ -339,7 +347,7 @@ else
   cross=
 fi
 echo "Checking for C compiler..."
-trycc ${cross}${CC}
+trycc "${cross}${CC}"
 trycc ${cross}gcc
 trycc ${cross}clang
 trycc ${cross}cc


### PR DESCRIPTION
for example: ccache gcc hello.c -o hello

We have to check if both ccache and gcc exist

edit: The "configure" file of the s6 repositories and the execline repository could make use of the same change