### PR TITLE
Make linker use dummy file when testing libs

### DIFF
--- a/configure
+++ b/configure
@@ -297,16 +297,16 @@ detectlibs () {
   name=$1
   shift
   if $CC_AUTO $CPPFLAGS_AUTO $CPPFLAGS $CPPFLAGS_POST $CFLAGS_AUTO $CFLAGS $CFLAGS_POST -c -o try$name.o src/sysdeps/try$name.c 2>/dev/null ; then
-    until $CC_AUTO $CFLAGS_AUTO $CFLAGS $CFLAGS_POST $LDFLAGS_AUTO $LDFLAGS $LDFLAGS_POST -o /dev/null try$name.o $args 2>/dev/null ; do
+    until $CC_AUTO $CFLAGS_AUTO $CFLAGS $CFLAGS_POST $LDFLAGS_AUTO $LDFLAGS $LDFLAGS_POST -o try$name try$name.o $args 2>/dev/null ; do
       if test -z "$*" ; then
-        rm -f try$name.o
+        rm -f try$name.o try$name
         return 1
       fi
       args="$args $1"
       shift
     done
     echo ${args# }
-    rm -f try$name.o
+    rm -f try$name.o try$name
     return 0
   else
     return 1


### PR DESCRIPTION
For some architectures, like Xtensa or HPPA, ld from binutils requires the output file to be a regular file, as mentioned in a bug report on the mailing list [1].

So, use a dummy file as output file for ld in trylibs(), instead of /dev/null.

[1] https://sourceware.org/bugzilla/show_bug.cgi?id=19526

Signed-off-by: Eric Le Bihan <eric.le.bihan.dev@free.fr>
[Fabrice: update patch for version 2.10.0.0]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>